### PR TITLE
most assumes cleaned up, file renames

### DIFF
--- a/NativeTypes.dfy
+++ b/NativeTypes.dfy
@@ -96,5 +96,5 @@ module NativeTypes {
 			&& b as int <= UINT32_MAX as int); // this should be provable
 		ensures a < 0 ==> (
 			&& reinterp64(a) as int - a as int == UINT64_MAX as int + 1
-			&& uh64(b) as int == UINT32_MAX as int + 1); // this should be provable
+			&& uh64(b) == UINT32_MAX); // this should be provable
 }

--- a/NativeTypes.dfy
+++ b/NativeTypes.dfy
@@ -91,5 +91,10 @@ module NativeTypes {
         ensures lh64(x) as int == x as int % (UINT32_MAX as int + 1);
 
     function method reinterpret_cast(a: int64) : uint64
-      ensures a >= 0 ==> a as int == reinterpret_cast(a) as int <= UINT32_MAX as int;
+      ensures a >= 0 ==> (
+        && a as int == reinterpret_cast(a) as int
+        && reinterpret_cast(a) as int <= UINT32_MAX as int);
+      ensures a < 0 ==> (
+        && reinterpret_cast(a) as int - a as int == UINT64_MAX as int + 1
+        && reinterpret_cast(a) as int > UINT32_MAX as int);
 }

--- a/NativeTypes.dfy
+++ b/NativeTypes.dfy
@@ -1,100 +1,100 @@
 module NativeTypes {
-    newtype{:nativeType "sbyte"} int8 = i:int | -0x80 <= i < 0x80
-    newtype{:nativeType "byte"} uint8 = i:int | 0 <= i < 0x100
-    newtype{:nativeType "short"} int16 = i:int | -0x8000 <= i < 0x8000
-    newtype{:nativeType "ushort"} uint16 = i:int | 0 <= i < 0x10000
-    newtype{:nativeType "int"} int32 = i:int | -0x80000000 <= i < 0x80000000
-    newtype{:nativeType "uint"} uint32 = i:int | 0 <= i < 0x100000000
-    newtype{:nativeType "long"} int64 = i:int | -0x8000000000000000 <= i < 0x8000000000000000
-    newtype{:nativeType "ulong"} uint64 = i:int | 0 <= i < 0x10000000000000000
-    newtype{:nativeType "sbyte"} nat8 = i:int | 0 <= i < 0x80
-    newtype{:nativeType "short"} nat16 = i:int | 0 <= i < 0x8000
-    newtype{:nativeType "int"} nat32 = i:int | 0 <= i < 0x80000000
-    newtype{:nativeType "long"} nat64 = i:int | 0 <= i < 0x8000000000000000
+ 	newtype{:nativeType "sbyte"} int8 = i:int | -0x80 <= i < 0x80
+ 	newtype{:nativeType "byte"} uint8 = i:int | 0 <= i < 0x100
+ 	newtype{:nativeType "short"} int16 = i:int | -0x8000 <= i < 0x8000
+ 	newtype{:nativeType "ushort"} uint16 = i:int | 0 <= i < 0x10000
+ 	newtype{:nativeType "int"} int32 = i:int | -0x80000000 <= i < 0x80000000
+ 	newtype{:nativeType "uint"} uint32 = i:int | 0 <= i < 0x100000000
+ 	newtype{:nativeType "long"} int64 = i:int | -0x8000000000000000 <= i < 0x8000000000000000
+ 	newtype{:nativeType "ulong"} uint64 = i:int | 0 <= i < 0x10000000000000000
+ 	newtype{:nativeType "sbyte"} nat8 = i:int | 0 <= i < 0x80
+ 	newtype{:nativeType "short"} nat16 = i:int | 0 <= i < 0x8000
+ 	newtype{:nativeType "int"} nat32 = i:int | 0 <= i < 0x80000000
+ 	newtype{:nativeType "long"} nat64 = i:int | 0 <= i < 0x8000000000000000
   
-    type uint2 = i: int | 0 <= i < 2
+ 	type uint2 = i: int | 0 <= i < 2
 
-    const UINT64_MAX :uint64 := 0xffffffffffffffff;
-    const UINT32_MAX :uint32 := 0xffffffff;
-    const UINT16_MAX :uint16 := 0xffff;
-    const INT64_MAX : int64 := 0x7fffffffffffffff;
-    const INT64_MIN : int64 := -0x7fffffffffffffff; // what?
+ 	const UINT64_MAX :uint64 := 0xffffffffffffffff;
+ 	const UINT32_MAX :uint32 := 0xffffffff;
+ 	const UINT16_MAX :uint16 := 0xffff;
+ 	const INT64_MAX : int64 := 0x7fffffffffffffff;
+ 	const INT64_MIN : int64 := -0x7fffffffffffffff; // what?
 
-    function method {:extern "NativeTypes", "xor8"} xor8(x:uint8, y:uint8) : uint8
+ 	function method {:extern "NativeTypes", "xor8"} xor8(x:uint8, y:uint8) : uint8
 
-    function method {:extern "NativeTypes", "xor16"} xor16(x:uint16, y:uint16) : uint16
-    function method {:extern "NativeTypes", "xor32"} xor32(x:uint32, y:uint32) : uint32
-    function method {:extern "NativeTypes", "xor64"} xor64(x:uint64, y:uint64) : uint64
+ 	function method {:extern "NativeTypes", "xor16"} xor16(x:uint16, y:uint16) : uint16
+ 	function method {:extern "NativeTypes", "xor32"} xor32(x:uint32, y:uint32) : uint32
+ 	function method {:extern "NativeTypes", "xor64"} xor64(x:uint64, y:uint64) : uint64
 
-    function method {:extern "NativeTypes", "or8"} or8(x:uint8, y:uint8) : uint8
-    function method {:extern "NativeTypes", "or16"} or16(x:uint16, y:uint16) : uint16
-    function method {:extern "NativeTypes", "or32"} or32(x:uint32, y:uint32) : uint32
-    function method {:extern "NativeTypes", "or64"} or64(x:uint64, y:uint64) : uint64
+ 	function method {:extern "NativeTypes", "or8"} or8(x:uint8, y:uint8) : uint8
+ 	function method {:extern "NativeTypes", "or16"} or16(x:uint16, y:uint16) : uint16
+ 	function method {:extern "NativeTypes", "or32"} or32(x:uint32, y:uint32) : uint32
+ 	function method {:extern "NativeTypes", "or64"} or64(x:uint64, y:uint64) : uint64
 
-    function method {:extern "NativeTypes", "and8"} and8(x:uint8, y:uint8) : (r:uint8)
-      ensures r <= x;
-      ensures r <= y;
+ 	function method {:extern "NativeTypes", "and8"} and8(x:uint8, y:uint8) : (r:uint8)
+		ensures r <= x;
+		ensures r <= y;
 
-    function method {:extern "NativeTypes", "and16"} and16(x:uint16, y:uint16) : uint16
-    function method {:extern "NativeTypes", "and32"} and32(x:uint32, y:uint32) : uint32
-    function method {:extern "NativeTypes", "and64"} and64(x:uint64, y:uint64) : (r:uint64)
-      ensures r <= x && r <= y && (r == x || r == y);
+ 	function method {:extern "NativeTypes", "and16"} and16(x:uint16, y:uint16) : uint16
+ 	function method {:extern "NativeTypes", "and32"} and32(x:uint32, y:uint32) : uint32
+ 	function method {:extern "NativeTypes", "and64"} and64(x:uint64, y:uint64) : (r:uint64)
+ 	  ensures r <= x && r <= y && (r == x || r == y);
 
-    function method {:extern "NativeTypes", "lshift8"} lshift8(x:uint8, y:uint8) : uint8
-    function method {:extern "NativeTypes", "lshift16"} lshift16(x:uint16, y:uint16) : uint16
-    function method {:extern "NativeTypes", "lshift32"} lshift32(x:uint32, y:uint32) : uint32
-    function method {:extern "NativeTypes", "lshift64"} lshift64(x:uint64, y:uint64) : uint64
+ 	function method {:extern "NativeTypes", "lshift8"} lshift8(x:uint8, y:uint8) : uint8
+ 	function method {:extern "NativeTypes", "lshift16"} lshift16(x:uint16, y:uint16) : uint16
+ 	function method {:extern "NativeTypes", "lshift32"} lshift32(x:uint32, y:uint32) : uint32
+ 	function method {:extern "NativeTypes", "lshift64"} lshift64(x:uint64, y:uint64) : uint64
 
-    function method {:extern "NativeTypes", "not64"} not64(x:uint64) : uint64
+ 	function method {:extern "NativeTypes", "not64"} not64(x:uint64) : uint64
 
-    // Compute max of two values
-    function method maxi64 (x:int64, y:int64): (r:int64)
-      ensures r >= x;
-      ensures r >= y;
-    {
-        if x > y then x else y
-    }
+ 	// Compute max of two values
+ 	function method maxi64 (x:int64, y:int64): (r:int64)
+		ensures r >= x;
+		ensures r >= y;
+ 	{
+ 	 	if x > y then x else y
+ 	}
 
-    // Compute max of two values
-    function method maxu64 (x:uint64, y:uint64): (r:uint64)
-      ensures r >= x;
-      ensures r >= y;
-    {
-        if x > y then x else y
-    }
+ 	// Compute max of two values
+ 	function method maxu64 (x:uint64, y:uint64): (r:uint64)
+		ensures r >= x;
+		ensures r >= y;
+ 	{
+ 	 	if x > y then x else y
+ 	}
 
-    // Compute min of two values
-    function method minu32 (x:uint32, y:uint32): (r:uint32)
-      ensures r <= x;
-      ensures r <= y;
-    {
-        if x > y then y else x
-    }
+ 	// Compute min of two values
+ 	function method minu32 (x:uint32, y:uint32): (r:uint32)
+		ensures r <= x;
+		ensures r <= y;
+ 	{
+ 	 	if x > y then y else x
+ 	}
 
-    // Compute min of two values
-    function method minu64 (x:uint64, y:uint64): (r:uint64)
-      ensures r <= x;
-      ensures r <= y;
-    {
-        if x > y then y else x
-    }
+ 	// Compute min of two values
+ 	function method minu64 (x:uint64, y:uint64): (r:uint64)
+		ensures r <= x;
+		ensures r <= y;
+ 	{
+ 	 	if x > y then y else x
+ 	}
 
-    method {:extern "NativeTypes", "split64"} split64(x: uint64) returns (lower: uint32, upper: uint32)
-        ensures upper as int * (UINT32_MAX as int + 1) + lower as int == x as int;
+ 	method {:extern "NativeTypes", "split64"} split64(x: uint64) returns (lower: uint32, upper: uint32)
+ 	 	ensures upper as int * (UINT32_MAX as int + 1) + lower as int == x as int;
 
-    function method lh64(x: uint64) : (r: uint32)
+ 	function method lh64(x: uint64) : (r: uint32)
 
-    function method uh64(x: uint64) : (r: uint32)
+ 	function method uh64(x: uint64) : (r: uint32)
 
-    lemma split64_lemma(x: uint64)
-        ensures uh64(x) as int * (UINT32_MAX as int + 1) + lh64(x) as int == x as int;
-        ensures lh64(x) as int == x as int % (UINT32_MAX as int + 1);
+ 	lemma split64_lemma(x: uint64)
+ 	 	ensures uh64(x) as int * (UINT32_MAX as int + 1) + lh64(x) as int == x as int;
+ 	 	ensures lh64(x) as int == x as int % (UINT32_MAX as int + 1);
 
-    function method reinterpret_cast(a: int64) : uint64
-      ensures a >= 0 ==> (
-        && a as int == reinterpret_cast(a) as int
-        && reinterpret_cast(a) as int <= UINT32_MAX as int);
-      ensures a < 0 ==> (
-        && reinterpret_cast(a) as int - a as int == UINT64_MAX as int + 1
-        && reinterpret_cast(a) as int > UINT32_MAX as int);
+ 	function method reinterp64(a: int64) : uint64
+ 	  ensures a >= 0 ==> (
+ 	 	&& a as int == reinterp64(a) as int
+ 	 	&& reinterp64(a) as int <= UINT32_MAX as int); // this caluse should be provable
+ 	  ensures a < 0 ==> (
+ 	 	&& reinterp64(a) as int - a as int == UINT64_MAX as int + 1
+	 	&& uh64(reinterp64(a)) as int == UINT32_MAX as int + 1); // this caluse should be provable
 }

--- a/NativeTypes.dfy
+++ b/NativeTypes.dfy
@@ -90,11 +90,11 @@ module NativeTypes {
  	 	ensures uh64(x) as int * (UINT32_MAX as int + 1) + lh64(x) as int == x as int;
  	 	ensures lh64(x) as int == x as int % (UINT32_MAX as int + 1);
 
- 	function method reinterp64(a: int64) : uint64
- 	  ensures a >= 0 ==> (
- 	 	&& a as int == reinterp64(a) as int
- 	 	&& reinterp64(a) as int <= UINT32_MAX as int); // this caluse should be provable
- 	  ensures a < 0 ==> (
- 	 	&& reinterp64(a) as int - a as int == UINT64_MAX as int + 1
-	 	&& uh64(reinterp64(a)) as int == UINT32_MAX as int + 1); // this caluse should be provable
+ 	function method reinterp64(a: int64) : (b: uint64)
+		ensures a >= 0 ==> (
+			&& a as int == b as int
+			&& b as int <= UINT32_MAX as int); // this should be provable
+		ensures a < 0 ==> (
+			&& reinterp64(a) as int - a as int == UINT64_MAX as int + 1
+			&& uh64(b) as int == UINT32_MAX as int + 1); // this should be provable
 }

--- a/NativeTypes.dfy
+++ b/NativeTypes.dfy
@@ -89,4 +89,7 @@ module NativeTypes {
     lemma split64_lemma(x: uint64)
         ensures uh64(x) as int * (UINT32_MAX as int + 1) + lh64(x) as int == x as int;
         ensures lh64(x) as int == x as int % (UINT32_MAX as int + 1);
+
+    function method reinterpret_cast(a: int64) : uint64
+      ensures a >= 0 ==> a as int == reinterpret_cast(a) as int <= UINT32_MAX as int;
 }

--- a/RSAE3v0.dfy
+++ b/RSAE3v0.dfy
@@ -1,6 +1,6 @@
 include "Powers.dfy"
 
-module MONTGOMERY {
+module RSAE3v0 {
     import opened Powers
 
     predicate cong_def(a: int, b: int, n: int)

--- a/RSAE3v1.dfy
+++ b/RSAE3v1.dfy
@@ -3,7 +3,7 @@ include "Powers.dfy"
 include "Congruences.dfy"
 include "SeqInt.dfy"
 
-module RSAE3 {
+module RSAE3v1 {
     import opened NativeTypes
     import opened Powers
     import opened Congruences

--- a/RSAE3v2.dfy
+++ b/RSAE3v2.dfy
@@ -2,14 +2,14 @@ include "NativeTypes.dfy"
 include "Powers.dfy"
 include "Congruences.dfy"
 include "SeqInt.dfy"
-include "RSAE3.dfy"
+include "RSAE3v1.dfy"
 
 module RSAE3v2 {
     import opened NativeTypes
     import opened Powers
     import opened Congruences
     import opened SeqInt
-    import opened RSAE3
+    import opened RSAE3v1
 
     lemma cmm_divisible_lemma(p_1: nat, p_2: nat, x_i: nat, y_0: nat, a_0: nat, u_i: nat, m': nat, m_0: nat)
         requires cong(m' * m_0, -1, BASE);

--- a/SeqInt.dfy
+++ b/SeqInt.dfy
@@ -404,7 +404,7 @@ module SeqInt {
             assert interp(A, i_old) - interp(B, i_old) == interp(S, i_old) - b_old as int * postional_weight(i_old);
 
             var diff: int64 := A[i] as int64 - B[i] as int64 - b as int64;
-            var casted: uint64 := reinterpret_cast(diff);
+            var casted: uint64 := reinterp64(diff);
             var masked := lh64(casted);
 
             if diff >= 0 {
@@ -416,8 +416,6 @@ module SeqInt {
                 split64_lemma(casted);
 
                 ghost var upper := uh64(casted) as int;
-                assume upper == UINT32_MAX as int;
-
                 assert masked as int + upper * BASE == casted as int;
                 assert masked as int == UINT64_MAX as int + 1 - upper * BASE + diff as int;
                 assert masked as int == diff as int + BASE as int;

--- a/SeqInt.dfy
+++ b/SeqInt.dfy
@@ -9,8 +9,6 @@ module SeqInt {
 
     const BASE :int := UINT32_MAX as int + 1;
 
-    function method reinterpret_cast(a: int64) : uint64
-
     // |A[..n]| == n, interp A[..n] as an int 
     function interp(A: seq<uint32>, n: nat) : nat
         decreases n;
@@ -406,10 +404,17 @@ module SeqInt {
             assert interp(A, i_old) - interp(B, i_old) == interp(S, i_old) - b_old as int * postional_weight(i_old);
 
             var diff: int64 := A[i] as int64 - B[i] as int64 - b as int64;
-            var masked := and64(reinterpret_cast(diff), UINT32_MAX as uint64) as uint32;
+            var casted: uint64 := reinterpret_cast(diff);
+            var masked := lh64(casted);
 
+            if diff >= 0 {
+                assert casted as int <= UINT32_MAX as int;
+                split64_lemma(casted);
+                assert masked as int == casted as int == diff as int;
+            }
+
+            // var masked := and64(casted, UINT32_MAX as uint64) as uint32;
             assume diff < 0 ==> masked as int == diff as int + BASE as int;
-            assume diff >= 0 ==> masked as int == diff as int;
 
             ghost var S_old := S;
             ghost var prefix_sum := interp(S_old, i);

--- a/SeqInt.dfy
+++ b/SeqInt.dfy
@@ -411,10 +411,17 @@ module SeqInt {
                 assert casted as int <= UINT32_MAX as int;
                 split64_lemma(casted);
                 assert masked as int == casted as int == diff as int;
-            }
+            } else {
+                assert casted as int - diff as int == UINT64_MAX as int + 1;
+                split64_lemma(casted);
 
-            // var masked := and64(casted, UINT32_MAX as uint64) as uint32;
-            assume diff < 0 ==> masked as int == diff as int + BASE as int;
+                ghost var upper := uh64(casted) as int;
+                assume upper == UINT32_MAX as int;
+
+                assert masked as int + upper * BASE == casted as int;
+                assert masked as int == UINT64_MAX as int + 1 - upper * BASE + diff as int;
+                assert masked as int == diff as int + BASE as int;
+            }
 
             ghost var S_old := S;
             ghost var prefix_sum := interp(S_old, i);


### PR DESCRIPTION
There are some assumes int `RSAE3v0.dfy`, which we don't import from other versions.
There is only one assume for `mod_mul_lemma` in `Congruences`, which is a provable case, but dafny is being weird.
Updated the ensures of `reinterp64`, had introduced false there (yikes).

